### PR TITLE
Add Makefile for building and pushing container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,13 @@ RUN cd /src \
     && make -j \
     && make install
 
+# These are the lua configurations for TPCC with the changes needed to work with
+# Vitess.
 RUN git clone https://github.com/planetscale/sysbench-tpcc.git /sysbench/sysbench-tpcc
+
+# This is pointing to master as of 2019-08-28, so we know given a particular
+# docker image which version we are using.
+RUN cd /sysbench/sysbench-tpcc && git checkout a0783efc2dda45e4f0eb765de06a452aa34c46dc
 
 RUN chgrp -R 0 /sysbench && chmod -R g=u /sysbench 
 

--- a/Makefile.docker-build
+++ b/Makefile.docker-build
@@ -1,0 +1,14 @@
+.PHONY: build push
+
+IMAGE:=registry.planetscale.com/vitess/sysbench
+
+build:
+	docker build .
+
+push: DATE=$(shell date -I)
+push: GITHASH=$(shell git log -1 --pretty=format:"%H")
+push: build
+	docker push $(IMAGE):latest
+	docker tag $(IMAGE):latest $(IMAGE):$(DATE)-$(GITHASH)
+	docker push $(IMAGE):$(DATE)-$(GITHASH)
+

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
     - [Linux](#linux)
     - [macOS](#macos)
     - [Windows](#windows)
+- [Building Docker Container](#building-docker-container)
 - [Building and Installing From Source](#building-and-installing-from-source)
     - [Build Requirements](#build-requirements)
         - [Windows](#windows)
@@ -110,6 +111,17 @@ After installing WSL and getting into he bash prompt on Windows
 following Debian/Ubuntu installation instructions is
 sufficient. Alternatively, one can use WSL to build and install sysbench
 from source, or use an older sysbench release to build a native binary.
+
+# Building Docker Container
+
+From this directory run:
+
+```
+make -f Makefile.docker-build build
+```
+
+That Makefile also has a `push` directive to push to `registry.planetscale.com`
+with images that are tagged with date and git hash.
 
 # Building and Installing From Source
 


### PR DESCRIPTION
This also pins the versions of everything so we can record what version of these scripts we tested with.