### PR TITLE
Tweaks automake and tpch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -404,6 +404,7 @@ src/tests/fileio/Makefile
 src/tests/memory/Makefile
 src/tests/threads/Makefile
 src/tests/mutex/Makefile
+src/tests/tpch/Makefile
 src/lua/Makefile
 src/lua/internal/Makefile
 tests/Makefile

--- a/src/tests/tpch/sb_tpch.c
+++ b/src/tests/tpch/sb_tpch.c
@@ -154,7 +154,7 @@ static char *add_path_to_root(char *add)
 static char** get_script_arguments(const char *path)
 {
     const int nb_args = 4;
-    char args_str[nb_args][32] = {
+    char args_str[4][32] = {
             "--size",
             "",
             "--mysql-params",

--- a/src/tests/tpch/sb_tpch.c
+++ b/src/tests/tpch/sb_tpch.c
@@ -173,14 +173,13 @@ static char** get_script_arguments(const char *path)
     }
 
     for (int i = 0; i < nb_args; i++) {
-        args[i+1] = malloc(strlen(args_str[i]));
+        args[i+1] = strdup(args_str[i]);
         if (args[i+1] == NULL) {
             for (int j = i; j >= 0; j--)
                 free(args[j]);
             free(args);
             return NULL;
         }
-        strcpy(args[i+1], args_str[i]);
     }
     args[nb_args+1] = NULL;
     return args;


### PR DESCRIPTION
Fixing a couple of small issues encountered after deploying tpch such as:

- The script parameters array in `sb_tpch.c` would not compile with `C90`, the `Fixed ISO C90 forbids array` was thrown by GCC
- Use of `strdup` instead of `strcpy` as mentioned in [this](https://github.com/planetscale/sysbench/pull/2#discussion_r674813591) comment
- Automake had a missing field in the `AC_CONFIG_FILES ` list